### PR TITLE
Display room exits on screen

### DIFF
--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -8,6 +8,11 @@ const game = useGameStore()
   <div>
     <h1>Text Adventure Game</h1>
     <p>{{ game.room.description }}</p>
+    <ul>
+      <li v-for="direction in Object.keys(game.room.exits)" :key="direction">
+        {{ direction }}
+      </li>
+    </ul>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- show exits on the GameScreen

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68730fa4446c832f999b71ef9e018e1d