### PR TITLE
Add simple canvas map of visited rooms

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,5 +8,6 @@ A short overview of the features planned for the text adventure project.
 - **Quests and objectives** that guide the player through the story.
 - **Simple combat system** that allows fighting enemies in turn-based style.
 - **Save and load support** so players can continue their adventure.
+- **Map of visited rooms** drawn on a small canvas as you explore.
 
 These features are meant to provide a classic adventure experience in the browser using a lightweight Vue application.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ src/
 
 Modify files in `src/data` and `src/components` to extend the game, create new scenes or add features.
 
+A small map below the room description shows the locations you have already visited. Each room is drawn as a square with openings for any available exits and your current location highlighted.
+
 ## License
 
 MIT

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useGameStore } from '../store/game'
+import MapCanvas from './MapCanvas.vue'
 
 const game = useGameStore()
 const command = ref('')
@@ -20,6 +21,7 @@ function handleCommand() {
     <v-card-title>Text Adventure Game</v-card-title>
     <v-card-text>
       <p>{{ game.room.description }}</p>
+      <MapCanvas :visited="game.visited" :current="game.currentRoom" class="mb-4" />
       <div class="my-2">
         <v-btn
           v-for="direction in Object.keys(game.room.exits)"

--- a/src/components/MapCanvas.vue
+++ b/src/components/MapCanvas.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { watchEffect, ref } from 'vue'
+import { world } from '../data/world'
+
+interface Visited {
+  [room: string]: { x: number; y: number }
+}
+
+const props = defineProps<{
+  visited: Visited
+  current: string
+}>()
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+
+const cellSize = 40
+
+function draw() {
+  const cvs = canvas.value
+  if (!cvs) return
+  const ctx = cvs.getContext('2d')
+  if (!ctx) return
+
+  const coords = Object.values(props.visited)
+  if (!coords.length) return
+
+  const xs = coords.map(c => c.x)
+  const ys = coords.map(c => c.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+
+  const width = (maxX - minX + 1) * cellSize
+  const height = (maxY - minY + 1) * cellSize
+  cvs.width = width
+  cvs.height = height
+
+  ctx.clearRect(0, 0, width, height)
+  ctx.strokeStyle = '#000'
+  ctx.lineWidth = 2
+
+  for (const [room, coord] of Object.entries(props.visited)) {
+    const exits = world[room].exits
+    const x = (coord.x - minX) * cellSize
+    const y = (coord.y - minY) * cellSize
+    ctx.beginPath()
+    if (!exits.north) {
+      ctx.moveTo(x, y)
+      ctx.lineTo(x + cellSize, y)
+    }
+    if (!exits.south) {
+      ctx.moveTo(x, y + cellSize)
+      ctx.lineTo(x + cellSize, y + cellSize)
+    }
+    if (!exits.west) {
+      ctx.moveTo(x, y)
+      ctx.lineTo(x, y + cellSize)
+    }
+    if (!exits.east) {
+      ctx.moveTo(x + cellSize, y)
+      ctx.lineTo(x + cellSize, y + cellSize)
+    }
+    ctx.stroke()
+
+    if (props.current === room) {
+      ctx.fillStyle = 'rgba(100,200,100,0.3)'
+      ctx.fillRect(x + 3, y + 3, cellSize - 6, cellSize - 6)
+    }
+  }
+}
+
+watchEffect(draw)
+</script>
+
+<template>
+  <canvas ref="canvas"></canvas>
+</template>
+
+<style scoped>
+canvas {
+  border: 1px solid #ccc;
+}
+</style>

--- a/src/store/game.ts
+++ b/src/store/game.ts
@@ -1,9 +1,11 @@
 import { defineStore } from 'pinia'
 import { world } from '../data/world'
+import type { Coordinates } from '../types/world'
 
 export const useGameStore = defineStore('game', {
   state: () => ({
-    currentRoom: 'start'
+    currentRoom: 'start',
+    visited: { start: { x: 0, y: 0 } } as Record<string, Coordinates>
   }),
   getters: {
     room: (state) => world[state.currentRoom]
@@ -12,6 +14,18 @@ export const useGameStore = defineStore('game', {
     move(direction: string) {
       const next = world[this.currentRoom].exits[direction]
       if (next) {
+        const offset: Record<string, [number, number]> = {
+          north: [0, -1],
+          south: [0, 1],
+          east: [1, 0],
+          west: [-1, 0]
+        }
+        const [dx, dy] = offset[direction] || [0, 0]
+        const current = this.visited[this.currentRoom] || { x: 0, y: 0 }
+        const coords = { x: current.x + dx, y: current.y + dy }
+        if (!this.visited[next]) {
+          this.visited[next] = coords
+        }
         this.currentRoom = next
       }
     }

--- a/src/types/world.ts
+++ b/src/types/world.ts
@@ -4,3 +4,8 @@ export interface Room {
 }
 
 export type World = Record<string, Room>
+
+export interface Coordinates {
+  x: number
+  y: number
+}


### PR DESCRIPTION
## Summary
- track visited rooms with coordinates in Pinia store
- draw visited rooms on a small `<canvas>` with new `MapCanvas` component
- show the map on the main game screen
- document the feature in README and FEATURES list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68733835d278832fa3a259961f479c89