### PR TITLE
Add keyboard movement and side panel controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Modify files in `src/data` and `src/components` to extend the game, create new s
 
 A small map below the room description shows the locations you have already visited. Each room is drawn as a square with openings for any available exits and your current location highlighted.
 
+You can navigate using the on-screen arrow buttons or with your keyboard. Both the arrow keys and the classic `W`, `A`, `S`, `D` keys trigger movement between rooms.
+
 ## License
 
 MIT

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import GameScreen from './components/GameScreen.vue'
 <template>
   <v-app>
     <v-main>
-      <v-container class="text-center">
+      <v-container fluid class="pa-0">
         <GameScreen />
       </v-container>
     </v-main>

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -1,28 +1,75 @@
 <script setup lang="ts">
 import { useGameStore } from '../store/game'
 import MapCanvas from './MapCanvas.vue'
+import { useKeyboardMovement } from '../composables/useKeyboardMovement'
 
 const game = useGameStore()
+useKeyboardMovement(game.move)
 </script>
 
 <template>
-  <v-card class="mx-auto" max-width="400">
-    <v-card-title>Text Adventure Game</v-card-title>
-    <v-card-text>
-      <p>{{ game.room.description }}</p>
-      <MapCanvas :visited="game.visited" :current="game.currentRoom" class="mb-4" />
-      <div class="my-2">
+  <v-row no-gutters>
+    <v-col class="pr-0">
+      <v-card class="w-100">
+        <v-card-title>Text Adventure Game</v-card-title>
+        <v-card-text>
+          <p>{{ game.room.description }}</p>
+          <MapCanvas :visited="game.visited" :current="game.currentRoom" class="mb-4" />
+        </v-card-text>
+      </v-card>
+    </v-col>
+    <v-col cols="3" class="side-panel d-flex flex-column">
+      <div class="flex-grow-1"></div>
+      <div class="d-flex flex-column align-center mb-4">
         <v-btn
-          v-for="direction in Object.keys(game.room.exits)"
-          :key="direction"
-          class="ma-1"
-          @click="game.move(direction)"
+          icon
+          class="direction-btn mb-1"
+          aria-label="Go north"
+          :disabled="!game.room.exits.north"
+          @click="game.move('north')"
         >
-          Go {{ direction }}
+          <v-icon>mdi-arrow-up</v-icon>
+        </v-btn>
+        <div>
+          <v-btn
+            icon
+            class="direction-btn mr-1"
+            aria-label="Go west"
+            :disabled="!game.room.exits.west"
+            @click="game.move('west')"
+          >
+            <v-icon>mdi-arrow-left</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            class="direction-btn ml-1"
+            aria-label="Go east"
+            :disabled="!game.room.exits.east"
+            @click="game.move('east')"
+          >
+            <v-icon>mdi-arrow-right</v-icon>
+          </v-btn>
+        </div>
+        <v-btn
+          icon
+          class="direction-btn mt-1"
+          aria-label="Go south"
+          :disabled="!game.room.exits.south"
+          @click="game.move('south')"
+        >
+          <v-icon>mdi-arrow-down</v-icon>
         </v-btn>
       </div>
-    </v-card-text>
-  </v-card>
+    </v-col>
+  </v-row>
 </template>
 
-<style scoped></style>
+<style scoped>
+.side-panel {
+  min-width: 100px;
+}
+.direction-btn {
+  width: 40px;
+  height: 40px;
+}
+</style>

--- a/src/composables/useKeyboardMovement.ts
+++ b/src/composables/useKeyboardMovement.ts
@@ -1,0 +1,34 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export type Direction = 'north' | 'south' | 'east' | 'west'
+
+/**
+ * Sets up global keyboard listeners for WASD and arrow keys.
+ * When a matching key is pressed, the provided move callback
+ * is called with the corresponding direction.
+ *
+ * @param move - function that performs movement in a given direction
+ */
+export function useKeyboardMovement(move: (direction: Direction) => void) {
+  const keyMap: Record<string, Direction> = {
+    ArrowUp: 'north',
+    w: 'north',
+    ArrowDown: 'south',
+    s: 'south',
+    ArrowLeft: 'west',
+    a: 'west',
+    ArrowRight: 'east',
+    d: 'east'
+  }
+
+  const handler = (e: KeyboardEvent) => {
+    const dir = keyMap[e.key]
+    if (dir) {
+      e.preventDefault()
+      move(dir)
+    }
+  }
+
+  onMounted(() => window.addEventListener('keydown', handler))
+  onUnmounted(() => window.removeEventListener('keydown', handler))
+}

--- a/tests/components/GameScreen.spec.ts
+++ b/tests/components/GameScreen.spec.ts
@@ -15,11 +15,18 @@ function renderGame() {
 
 describe('GameScreen', () => {
   it('displays room description and moves when button clicked', async () => {
-    const { getByText } = renderGame()
+    const { getByText, getByLabelText, getAllByText } = renderGame()
 
     getByText('dimly lit room', { exact: false })
-    const btn = getByText('Go north')
+    const btn = getByLabelText('Go north')
     await fireEvent.click(btn)
-    getByText('long hallway', { exact: false })
+    getAllByText('long hallway', { exact: false })
+  })
+
+  it('moves with keyboard arrows', async () => {
+    const { getByText, getAllByText } = renderGame()
+    getByText('dimly lit room', { exact: false })
+    await fireEvent.keyDown(window, { key: 'ArrowUp' })
+    getAllByText('long hallway', { exact: false })
   })
 })

--- a/tests/composables/useKeyboardMovement.spec.ts
+++ b/tests/composables/useKeyboardMovement.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/vue'
+import { createTestingPinia } from '@pinia/testing'
+import { defineComponent } from 'vue'
+import { useGameStore } from '../../src/store/game'
+import { useKeyboardMovement } from '../../src/composables/useKeyboardMovement'
+
+const TestComponent = defineComponent({
+  setup() {
+    const game = useGameStore()
+    useKeyboardMovement(game.move)
+    return {}
+  },
+  template: '<div>Test</div>'
+})
+
+describe('useKeyboardMovement', () => {
+  it('triggers movement on WASD and arrow keys', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    render(TestComponent, { global: { plugins: [pinia] } })
+    const game = useGameStore()
+
+    await fireEvent.keyDown(window, { key: 'ArrowUp' })
+    expect(game.move).toHaveBeenCalledWith('north')
+
+    await fireEvent.keyDown(window, { key: 'd' })
+    expect(game.move).toHaveBeenCalledWith('east')
+  })
+
+  it('ignores unrelated keys', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    render(TestComponent, { global: { plugins: [pinia] } })
+    const game = useGameStore()
+
+    await fireEvent.keyDown(window, { key: 'x' })
+    expect(game.move).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- make app container fluid
- add side panel with arrow buttons
- support keyboard movement via WASD or arrow keys
- document keyboard controls in README
- test GameScreen updates and new `useKeyboardMovement` composable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68733beabbf8832f9e059a97acf6644a