### PR TITLE
Add player stats and calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This project aims to grow into a full text adventure experience. The following f
 - Turn-based RPG battle system with player and enemy stats, critical hits and rewards.
 - Save and load support.
 - Map of visited rooms drawn on a canvas.
+- Sidebar displays calculated character stats like damage and attack speed.
 
 ## License
 

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useGameStore } from '../store/game'
+import { usePlayerStore } from '../store/player'
 import MapCanvas from './MapCanvas.vue'
 import { useKeyboardMovement } from '../composables/useKeyboardMovement'
 
 const game = useGameStore()
+const player = usePlayerStore()
 useKeyboardMovement(game.move)
 </script>
 
@@ -19,6 +21,18 @@ useKeyboardMovement(game.move)
       </v-card>
     </v-col>
     <v-col cols="3" class="side-panel d-flex flex-column">
+      <v-card class="mb-2">
+        <v-card-title>Stats</v-card-title>
+        <v-card-text>
+          <div>Min Damage: {{ player.minDamage }}</div>
+          <div>Max Damage: {{ player.maxDamage.toFixed(1) }}</div>
+          <div>Attack Speed: {{ player.attackSpeed.toFixed(2) }} /s</div>
+          <div class="mt-2">Strength: {{ player.strength }}</div>
+          <div>Agility: {{ player.agility }}</div>
+          <div>Vitality: {{ player.vitality }}</div>
+          <div>Intelligence: {{ player.intelligence }}</div>
+        </v-card-text>
+      </v-card>
       <div class="flex-grow-1"></div>
       <div class="d-flex flex-column align-center mb-4">
         <v-btn

--- a/src/game/__tests__/character.spec.ts
+++ b/src/game/__tests__/character.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { calculateMinDamage, calculateMaxDamage, calculateAttackSpeed } from '../character'
+
+const stats = { baseMinDamage: 2, baseMaxDamage: 4, baseAttackSpeed: 1.5 }
+const attrs = { strength: 3, agility: 2, vitality: 1, intelligence: 1 }
+
+describe('character calculations', () => {
+  it('calculates min and max damage correctly', () => {
+    expect(calculateMinDamage(stats, attrs)).toBe(5)
+    expect(calculateMaxDamage(stats, attrs)).toBeCloseTo(8.5)
+  })
+
+  it('calculates attack speed with agility', () => {
+    const speed = calculateAttackSpeed(stats, attrs)
+    expect(speed).toBeCloseTo(Math.log(1.5) + 0.2)
+  })
+})

--- a/src/game/character.ts
+++ b/src/game/character.ts
@@ -1,0 +1,42 @@
+export interface BaseStats {
+  baseMinDamage: number
+  baseMaxDamage: number
+  baseAttackSpeed: number
+}
+
+export interface Attributes {
+  strength: number
+  agility: number
+  vitality: number
+  intelligence: number
+}
+
+/**
+ * Calculate the player's minimum damage.
+ * @param stats - base damage numbers
+ * @param attrs - attribute values
+ */
+export function calculateMinDamage(stats: BaseStats, attrs: Attributes): number {
+  return stats.baseMinDamage + attrs.strength
+}
+
+/**
+ * Calculate the player's maximum damage.
+ * @param stats - base damage numbers
+ * @param attrs - attribute values
+ */
+export function calculateMaxDamage(stats: BaseStats, attrs: Attributes): number {
+  return stats.baseMaxDamage + attrs.strength * 1.5
+}
+
+/**
+ * Calculate attacks per second based on base attack speed and agility.
+ * Uses a logarithmic scaling for diminishing returns.
+ *
+ * @param stats - base attack speed value
+ * @param attrs - attribute values
+ * @returns number of attacks per second
+ */
+export function calculateAttackSpeed(stats: BaseStats, attrs: Attributes): number {
+  return Math.log(stats.baseAttackSpeed) + attrs.agility * 0.1
+}

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia'
+import {
+  calculateMinDamage,
+  calculateMaxDamage,
+  calculateAttackSpeed,
+  BaseStats,
+  Attributes
+} from '../game/character'
+
+export const usePlayerStore = defineStore('player', {
+  state: () => ({
+    baseMinDamage: 2,
+    baseMaxDamage: 4,
+    baseAttackSpeed: 1.5,
+    strength: 1,
+    agility: 1,
+    vitality: 1,
+    intelligence: 1
+  }),
+  getters: {
+    minDamage(state) {
+      return calculateMinDamage(state as BaseStats, state as Attributes)
+    },
+    maxDamage(state) {
+      return calculateMaxDamage(state as BaseStats, state as Attributes)
+    },
+    attackSpeed(state) {
+      return calculateAttackSpeed(state as BaseStats, state as Attributes)
+    }
+  }
+})

--- a/tests/components/GameScreen.spec.ts
+++ b/tests/components/GameScreen.spec.ts
@@ -18,6 +18,7 @@ describe('GameScreen', () => {
     const { getByText, getByLabelText, getAllByText } = renderGame()
 
     getByText('dimly lit room', { exact: false })
+    getByText('Min Damage: 3')
     const btn = getByLabelText('Go north')
     await fireEvent.click(btn)
     getAllByText('long hallway', { exact: false })
@@ -26,6 +27,7 @@ describe('GameScreen', () => {
   it('moves with keyboard arrows', async () => {
     const { getByText, getAllByText } = renderGame()
     getByText('dimly lit room', { exact: false })
+    expect(getAllByText(/Attack Speed:/).length).toBeGreaterThan(0)
     await fireEvent.keyDown(window, { key: 'ArrowUp' })
     getAllByText('long hallway', { exact: false })
   })

--- a/tests/store/player.spec.ts
+++ b/tests/store/player.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePlayerStore } from '../../src/store/player'
+
+describe('usePlayerStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('computes derived stats', () => {
+    const player = usePlayerStore()
+    expect(player.minDamage).toBe(3)
+    expect(player.maxDamage).toBeCloseTo(5.5)
+    expect(player.attackSpeed).toBeCloseTo(Math.log(1.5) + 0.1)
+  })
+})


### PR DESCRIPTION
## Summary
- create character stat utilities for damage and attack speed
- add player store with base stats and attribute values
- display computed stats in `GameScreen`
- cover new logic and component updates with tests
- document new stats sidebar in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873571ccbbc832fa24982d0c6830903