### PR TITLE
Add inventory system with panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ A small map below the room description shows the locations you have already visi
 
 You can navigate using the on-screen arrow buttons or with your keyboard. Both the arrow keys and the classic `W`, `A`, `S`, `D` keys trigger movement between rooms.
 
+## Inventory
+
+Some rooms contain items you can collect. The right side panel now displays an **Inventory** section listing everything you've picked up. Use the `pickUp` and `useItem` actions from the game store to manage these items in your own components or game logic.
+
 ## Features
 
 This project aims to grow into a full text adventure experience. The following features are currently planned:

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGameStore } from '../store/game'
 import MapCanvas from './MapCanvas.vue'
+import InventoryPanel from './InventoryPanel.vue'
 import { useKeyboardMovement } from '../composables/useKeyboardMovement'
 
 const game = useGameStore()
@@ -19,6 +20,7 @@ useKeyboardMovement(game.move)
       </v-card>
     </v-col>
     <v-col cols="3" class="side-panel d-flex flex-column">
+      <InventoryPanel class="mb-2" />
       <div class="flex-grow-1"></div>
       <div class="d-flex flex-column align-center mb-4">
         <v-btn

--- a/src/components/InventoryPanel.vue
+++ b/src/components/InventoryPanel.vue
@@ -1,0 +1,19 @@
+<!--
+Displays the player's current inventory items.
+-->
+<script setup lang="ts">
+import { useInventoryStore } from '../store/inventory'
+const inventory = useInventoryStore()
+</script>
+
+<template>
+  <v-card>
+    <v-card-title>Inventory</v-card-title>
+    <v-card-text>
+      <ul v-if="inventory.items.length">
+        <li v-for="item in inventory.items" :key="item.id">{{ item.name }}</li>
+      </ul>
+      <span v-else>No items</span>
+    </v-card-text>
+  </v-card>
+</template>

--- a/src/components/__tests__/InventoryPanel.spec.ts
+++ b/src/components/__tests__/InventoryPanel.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { render } from '@testing-library/vue'
+import { createTestingPinia } from '@pinia/testing'
+import InventoryPanel from '../InventoryPanel.vue'
+import { useInventoryStore } from '../../store/inventory'
+
+function renderPanel() {
+  const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+  const utils = render(InventoryPanel, { global: { plugins: [pinia] } })
+  return { ...utils, pinia }
+}
+
+describe('InventoryPanel', () => {
+  it('renders items from the store', async () => {
+    const { getByText } = renderPanel()
+    const store = useInventoryStore()
+    store.add({ id: 'torch', name: 'Torch', description: '' })
+    await nextTick()
+    getByText('Torch')
+  })
+
+  it('matches snapshot', () => {
+    const { container } = renderPanel()
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/__tests__/__snapshots__/InventoryPanel.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/InventoryPanel.spec.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`InventoryPanel > matches snapshot 1`] = `
+<div>
+  <v-card>
+    <v-card-title>
+      Inventory
+    </v-card-title>
+    <v-card-text>
+      <span>
+        No items
+      </span>
+    </v-card-text>
+  </v-card>
+</div>
+`;

--- a/src/data/world.ts
+++ b/src/data/world.ts
@@ -4,17 +4,45 @@ export const world: World = {
   start: {
     description: "You are in a dimly lit room. There’s a door to the north.",
     exits: { north: "hallway" },
+    items: [
+      {
+        id: 'torch',
+        name: 'Torch',
+        description: 'A handy torch to light your way.'
+      }
+    ]
   },
   hallway: {
     description: "You are in a long hallway. Doors lead east and west.",
     exits: { south: "start", east: "library", west: "kitchen" },
+    items: [
+      {
+        id: 'coin',
+        name: 'Gold Coin',
+        description: 'A shiny gold coin lying on the floor.'
+      }
+    ]
   },
   library: {
     description: "You enter a dusty library filled with old books.",
     exits: { west: "hallway" },
+    items: [
+      {
+        id: 'book',
+        name: 'Ancient Book',
+        description: 'An old tome with strange symbols.'
+      }
+    ]
   },
   kitchen: {
     description: "The kitchen smells of old food. There’s a knife here.",
     exits: { east: "hallway" },
+    items: [
+      {
+        id: 'knife',
+        name: 'Kitchen Knife',
+        description: 'Looks sharp enough to be useful.'
+      }
+    ]
   },
 };

--- a/src/store/game.ts
+++ b/src/store/game.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { world } from '../data/world'
-import type { Coordinates } from '../types/world'
+import type { Coordinates, Item } from '../types/world'
+import { useInventoryStore } from './inventory'
 
 export const useGameStore = defineStore('game', {
   state: () => ({
@@ -27,6 +28,23 @@ export const useGameStore = defineStore('game', {
           this.visited[next] = coords
         }
         this.currentRoom = next
+      }
+    },
+    /** Pick up an item from the current room and add it to the inventory */
+    pickUp(id: string) {
+      const room = world[this.currentRoom]
+      if (!room.items) return
+      const index = room.items.findIndex(i => i.id === id)
+      if (index !== -1) {
+        const [item] = room.items.splice(index, 1)
+        useInventoryStore().add(item)
+      }
+    },
+    /** Use an item from the inventory */
+    useItem(id: string) {
+      const inventory = useInventoryStore()
+      if (inventory.has(id)) {
+        inventory.remove(id)
       }
     }
   }

--- a/src/store/inventory.ts
+++ b/src/store/inventory.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import type { Item } from '../types/world'
+
+/**
+ * Pinia store managing items collected by the player.
+ */
+export const useInventoryStore = defineStore('inventory', {
+  state: () => ({
+    items: [] as Item[]
+  }),
+  actions: {
+    /** Add an item to the inventory */
+    add(item: Item) {
+      this.items.push(item)
+    },
+    /** Remove an item by id */
+    remove(id: string) {
+      this.items = this.items.filter(i => i.id !== id)
+    },
+    /** Check if an item is currently held */
+    has(id: string) {
+      return this.items.some(i => i.id === id)
+    }
+  }
+})

--- a/src/types/world.ts
+++ b/src/types/world.ts
@@ -1,6 +1,17 @@
+export interface Item {
+  /** Unique identifier for the item */
+  id: string
+  /** Display name */
+  name: string
+  /** Short description shown to the player */
+  description: string
+}
+
 export interface Room {
   description: string
   exits: Record<string, string>
+  /** Optional items that can be collected in this room */
+  items?: Item[]
 }
 
 export type World = Record<string, Room>

--- a/tests/components/GameScreen.spec.ts
+++ b/tests/components/GameScreen.spec.ts
@@ -8,7 +8,7 @@ function renderGame() {
   return render(GameScreen, {
     global: {
       plugins: [pinia],
-      stubs: ['MapCanvas']
+      stubs: ['MapCanvas', 'InventoryPanel']
     }
   })
 }

--- a/tests/store/inventory.spec.ts
+++ b/tests/store/inventory.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useInventoryStore } from '../../src/store/inventory'
+
+describe('useInventoryStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('adds and removes items', () => {
+    const store = useInventoryStore()
+    store.add({ id: 'torch', name: 'Torch', description: '' })
+    expect(store.items).toHaveLength(1)
+    expect(store.has('torch')).toBe(true)
+    store.remove('torch')
+    expect(store.items).toHaveLength(0)
+    expect(store.has('torch')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- extend world types to support items
- populate sample items in world data
- manage collected items via new inventory pinia store
- allow picking up and using items in the game store
- display items with new `InventoryPanel` component
- test inventory functionality and update existing tests
- document the inventory panel in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68735b8c6adc832fa5573fb9997ca3c0