### PR TITLE
Add player stats and combat calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ You can navigate using the on-screen arrow buttons or with your keyboard. Both t
 
 Some rooms contain items you can collect. The right side panel now displays an **Inventory** section listing everything you've picked up. Use the `pickUp` and `useItem` actions from the game store to manage these items in your own components or game logic.
 
+## Character Stats
+
+The new **Character** panel shows your attributes and calculated combat values. Attributes influence derived stats as follows:
+
+- **Strength** – increases minimum and maximum damage
+- **Agility** – increases attack speed
+- **Vitality** – increases health and regeneration (not yet implemented)
+- **Intelligence** – increases mana and regeneration (not yet implemented)
+
+Displayed combat stats include minimum damage, maximum damage and attacks per second. Base damage and attack speed values are stored internally and combined with the attributes.
+
 ## Features
 
 This project aims to grow into a full text adventure experience. The following features are currently planned:

--- a/src/components/CharacterPanel.vue
+++ b/src/components/CharacterPanel.vue
@@ -1,0 +1,24 @@
+<!--
+Displays the player's attributes and derived combat statistics.
+-->
+<script setup lang="ts">
+import { usePlayerStore } from '../store/player'
+
+const player = usePlayerStore()
+</script>
+
+<template>
+  <v-card>
+    <v-card-title>Character</v-card-title>
+    <v-card-text>
+      <p><strong>Strength:</strong> {{ player.strength }}</p>
+      <p><strong>Agility:</strong> {{ player.agility }}</p>
+      <p><strong>Vitality:</strong> {{ player.vitality }}</p>
+      <p><strong>Intelligence:</strong> {{ player.intelligence }}</p>
+      <hr />
+      <p><strong>Min Damage:</strong> {{ player.minDamage.toFixed(1) }}</p>
+      <p><strong>Max Damage:</strong> {{ player.maxDamage.toFixed(1) }}</p>
+      <p><strong>Attack Speed:</strong> {{ player.attackSpeed.toFixed(2) }} /s</p>
+    </v-card-text>
+  </v-card>
+</template>

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -2,6 +2,7 @@
 import { useGameStore } from '../store/game'
 import MapCanvas from './MapCanvas.vue'
 import InventoryPanel from './InventoryPanel.vue'
+import CharacterPanel from './CharacterPanel.vue'
 import { useKeyboardMovement } from '../composables/useKeyboardMovement'
 
 const game = useGameStore()
@@ -20,6 +21,7 @@ useKeyboardMovement(game.move)
       </v-card>
     </v-col>
     <v-col cols="3" class="side-panel d-flex flex-column">
+      <CharacterPanel class="mb-2" />
       <InventoryPanel class="mb-2" />
       <div class="flex-grow-1"></div>
       <div class="d-flex flex-column align-center mb-4">

--- a/src/components/__tests__/CharacterPanel.spec.ts
+++ b/src/components/__tests__/CharacterPanel.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/vue'
+import { nextTick } from 'vue'
+import { createTestingPinia } from '@pinia/testing'
+import CharacterPanel from '../CharacterPanel.vue'
+import { usePlayerStore } from '../../store/player'
+
+function renderPanel() {
+  const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+  const utils = render(CharacterPanel, { global: { plugins: [pinia] } })
+  return { ...utils, pinia }
+}
+
+describe('CharacterPanel', () => {
+  it('displays player attributes', async () => {
+    const { getByText } = renderPanel()
+    const store = usePlayerStore()
+    getByText(`Strength:`)
+    store.strength = 10
+    await nextTick()
+    getByText('10')
+  })
+})

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { calculateAttackSpeed } from '../utils/combat'
+
+/**
+ * Pinia store representing the player character.
+ * Contains base stats and derived combat attributes.
+ */
+export const usePlayerStore = defineStore('player', {
+  state: () => ({
+    baseMinDamage: 2,
+    baseMaxDamage: 4,
+    baseAttackSpeed: 1.2,
+    strength: 5,
+    agility: 3,
+    vitality: 4,
+    intelligence: 2
+  }),
+  getters: {
+    /** Minimum damage output including strength bonus */
+    minDamage: (s) => s.baseMinDamage + s.strength,
+    /** Maximum damage output including strength bonus */
+    maxDamage: (s) => s.baseMaxDamage + s.strength * 1.5,
+    /** Attacks per second after agility bonuses */
+    attackSpeed: (s) => calculateAttackSpeed(s.baseAttackSpeed, s.agility)
+  }
+})

--- a/src/utils/__tests__/combat.spec.ts
+++ b/src/utils/__tests__/combat.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { calculateAttackSpeed } from '../combat'
+
+describe('calculateAttackSpeed', () => {
+  it('returns larger values with more agility', () => {
+    const base = 1.5
+    const low = calculateAttackSpeed(base, 0)
+    const high = calculateAttackSpeed(base, 10)
+    expect(high).toBeGreaterThan(low)
+  })
+
+  it('handles base values below e', () => {
+    const speed = calculateAttackSpeed(0.5, 0)
+    expect(speed).toBeLessThan(0)
+  })
+})

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -1,0 +1,16 @@
+/**
+ * Utility functions for combat calculations.
+ */
+
+/**
+ * Calculate attacks per second using a logarithmic base value and agility
+ * modifier.
+ *
+ * @param baseAttackSpeed - the character's base attack speed
+ * @param agility - agility attribute value
+ * @returns calculated attacks per second
+ */
+export function calculateAttackSpeed(baseAttackSpeed: number, agility: number): number {
+  const agilityBonus = agility * 0.1
+  return Math.log(baseAttackSpeed) + agilityBonus
+}

--- a/tests/store/player.spec.ts
+++ b/tests/store/player.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePlayerStore } from '../../src/store/player'
+
+describe('usePlayerStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('computes derived stats correctly', () => {
+    const player = usePlayerStore()
+    player.strength = 2
+    player.agility = 1
+    expect(player.minDamage).toBe(player.baseMinDamage + player.strength)
+    expect(player.maxDamage).toBe(player.baseMaxDamage + player.strength * 1.5)
+    expect(player.attackSpeed).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- show character attributes and calculated combat stats
- derive combat values using a new `calculateAttackSpeed` helper
- manage player state in new Pinia store
- render CharacterPanel in GameScreen
- document the character panel in README
- test player store, CharacterPanel and combat utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68735ee09868832f91bc66940b3d5810