### PR TITLE
Autogenerate world from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ src/
 
 Modify files in `src/data` and `src/components` to extend the game, create new scenes or add features.
 
+### World Generation
+
+`src/data/world.ts` exports a configuration object and uses it to generate the game map. Rooms listed in the configuration are connected automatically with a reusable walkway room. Replacing or adjusting this configuration lets you create different levels without changing the game logic.
+
 A small map below the room description shows the locations you have already visited. Each room is drawn as a square with openings for any available exits and your current location highlighted.
 
 You can navigate using the on-screen arrow buttons or with your keyboard. Both the arrow keys and the classic `W`, `A`, `S`, `D` keys trigger movement between rooms.

--- a/src/data/world.ts
+++ b/src/data/world.ts
@@ -1,48 +1,48 @@
 import type { World } from '../types/world'
+import type { WorldConfig } from '../game/world'
+import { generateWorld } from '../game/world'
 
-export const world: World = {
-  start: {
-    description: "You are in a dimly lit room. There’s a door to the north.",
-    exits: { north: "hallway" },
-    items: [
-      {
-        id: 'torch',
-        name: 'Torch',
-        description: 'A handy torch to light your way.'
-      }
-    ]
+/** Default configuration used to build the initial game world. */
+export const defaultWorldConfig: WorldConfig = {
+  rooms: {
+    start: {
+      description: "You are in a dimly lit room. There’s a door to the north.",
+      exits: {},
+      items: [
+        { id: 'torch', name: 'Torch', description: 'A handy torch to light your way.' }
+      ]
+    },
+    kitchen: {
+      description: 'The kitchen smells of old food. There’s a knife here.',
+      exits: {},
+      items: [
+        { id: 'knife', name: 'Kitchen Knife', description: 'Looks sharp enough to be useful.' }
+      ]
+    },
+    living: {
+      description: 'You enter a cozy living room.',
+      exits: {},
+      items: [
+        { id: 'coin', name: 'Gold Coin', description: 'A shiny gold coin lying on the floor.' }
+      ]
+    },
+    bedroom: {
+      description: 'A messy bedroom with a comfy bed.',
+      exits: {},
+      items: [
+        { id: 'book', name: 'Ancient Book', description: 'An old tome with strange symbols.' }
+      ]
+    },
+    toilet: {
+      description: 'A small toilet with a flickering light.',
+      exits: {}
+    }
   },
-  hallway: {
-    description: "You are in a long hallway. Doors lead east and west.",
-    exits: { south: "start", east: "library", west: "kitchen" },
-    items: [
-      {
-        id: 'coin',
-        name: 'Gold Coin',
-        description: 'A shiny gold coin lying on the floor.'
-      }
-    ]
-  },
-  library: {
-    description: "You enter a dusty library filled with old books.",
-    exits: { west: "hallway" },
-    items: [
-      {
-        id: 'book',
-        name: 'Ancient Book',
-        description: 'An old tome with strange symbols.'
-      }
-    ]
-  },
-  kitchen: {
-    description: "The kitchen smells of old food. There’s a knife here.",
-    exits: { east: "hallway" },
-    items: [
-      {
-        id: 'knife',
-        name: 'Kitchen Knife',
-        description: 'Looks sharp enough to be useful.'
-      }
-    ]
-  },
-};
+  walkway: {
+    description: 'You are in a long hallway connecting rooms.',
+    exits: {}
+  }
+}
+
+/** Generated world used by the game stores and components. */
+export const world: World = generateWorld(defaultWorldConfig)

--- a/src/game/__tests__/world.spec.ts
+++ b/src/game/__tests__/world.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { generateWorld, WorldConfig } from '../world'
+
+const baseConfig: WorldConfig = {
+  rooms: {
+    start: { description: 'start', exits: {} },
+    a: { description: 'a', exits: {} },
+    b: { description: 'b', exits: {} }
+  },
+  walkway: { description: 'walk', exits: {} }
+}
+
+describe('generateWorld', () => {
+  it('creates a linear world using each room once', () => {
+    const world = generateWorld(baseConfig)
+    expect(Object.keys(world)).toEqual([
+      'start',
+      'walkway1',
+      'a',
+      'walkway2',
+      'b'
+    ])
+    expect(world.start.exits.north).toBe('walkway1')
+    expect(world.walkway1.exits.north).toBe('a')
+    expect(world.a.exits.south).toBe('walkway1')
+  })
+
+  it('throws when start room is missing', () => {
+    const bad: WorldConfig = { rooms: { a: { description: 'a', exits: {} } }, walkway: { description: 'w', exits: {} } }
+    expect(() => generateWorld(bad)).toThrow()
+  })
+})

--- a/src/game/world.ts
+++ b/src/game/world.ts
@@ -1,0 +1,44 @@
+import type { Room, World } from '../types/world'
+
+/** Configuration object used to generate a world layout. */
+export interface WorldConfig {
+  /** Rooms that should appear exactly once in the world. Must include a `start` room. */
+  rooms: Record<string, Omit<Room, 'exits'> & Partial<Pick<Room, 'exits'>>>
+  /** Template for the walkway room which will be duplicated to connect rooms. */
+  walkway: Omit<Room, 'exits'> & Partial<Pick<Room, 'exits'>>
+}
+
+/**
+ * Generate a world record from a configuration. Each defined room is used
+ * once while the walkway template is duplicated to connect them in a linear
+ * north–south fashion.
+ *
+ * @param config - world generation configuration
+ * @returns generated world object
+ */
+export function generateWorld(config: WorldConfig): World {
+  if (!config.rooms.start) {
+    throw new Error('Start room is required')
+  }
+
+  const world: World = {}
+  world.start = { ...config.rooms.start, exits: {} }
+
+  const others = Object.keys(config.rooms).filter(n => n !== 'start')
+  let previous = 'start'
+  others.forEach((name, idx) => {
+    const walkwayName = `walkway${idx + 1}`
+    world[walkwayName] = { ...config.walkway, exits: {} }
+    world[name] = { ...config.rooms[name], exits: {} }
+
+    world[previous].exits.north = walkwayName
+    world[walkwayName].exits.south = previous
+
+    world[walkwayName].exits.north = name
+    world[name].exits.south = walkwayName
+
+    previous = name
+  })
+
+  return world
+}

--- a/tests/store/game.spec.ts
+++ b/tests/store/game.spec.ts
@@ -14,11 +14,11 @@ describe('useGameStore', () => {
     expect(game.visited.start).toEqual({ x: 0, y: 0 })
 
     game.move('north')
-    expect(game.currentRoom).toBe('hallway')
-    expect(game.visited.hallway).toEqual({ x: 0, y: -1 })
+    expect(game.currentRoom).toBe('walkway1')
+    expect(game.visited.walkway1).toEqual({ x: 0, y: -1 })
 
-    game.move('east')
-    expect(game.currentRoom).toBe('library')
-    expect(game.visited.library).toEqual({ x: 1, y: -1 })
+    game.move('north')
+    expect(game.currentRoom).toBe('kitchen')
+    expect(game.visited.kitchen).toEqual({ x: 0, y: -2 })
   })
 })


### PR DESCRIPTION
## Summary
- implement `generateWorld` logic in new `src/game/world.ts`
- create default config in `src/data/world.ts` and generate map
- update game store tests for new layout
- add unit tests for world generation
- document world configuration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68737fc439c0832fb288533f3a51c499