### PR TITLE
Add random world generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Modify files in `src/data` and `src/components` to extend the game, create new s
 
 ### World Generation
 
-`src/data/world.ts` exports a configuration object and uses it to generate the game map. Rooms listed in the configuration are connected automatically with a reusable walkway room. Replacing or adjusting this configuration lets you create different levels without changing the game logic.
+`src/data/world.ts` exports a configuration object and uses it to generate the game map. Rooms listed in the configuration are connected automatically with a reusable walkway room. The order of rooms is randomized on each page load so the layout changes every time. Replacing or adjusting this configuration lets you create different levels without changing the game logic.
 
 A small map below the room description shows the locations you have already visited. Each room is drawn as a square with openings for any available exits and your current location highlighted.
 

--- a/src/game/__tests__/world.spec.ts
+++ b/src/game/__tests__/world.spec.ts
@@ -11,18 +11,25 @@ const baseConfig: WorldConfig = {
 }
 
 describe('generateWorld', () => {
-  it('creates a linear world using each room once', () => {
-    const world = generateWorld(baseConfig)
+  it('creates a linear world using each room once in random order', () => {
+    const rng = () => 0.2
+    const world = generateWorld(baseConfig, rng)
     expect(Object.keys(world)).toEqual([
       'start',
       'walkway1',
-      'a',
+      'b',
       'walkway2',
-      'b'
+      'a'
     ])
     expect(world.start.exits.north).toBe('walkway1')
-    expect(world.walkway1.exits.north).toBe('a')
-    expect(world.a.exits.south).toBe('walkway1')
+    expect(world.walkway1.exits.north).toBe('b')
+    expect(world.b.exits.south).toBe('walkway1')
+  })
+
+  it('produces different layouts when rng changes', () => {
+    const low = generateWorld(baseConfig, () => 0.2)
+    const high = generateWorld(baseConfig, () => 0.8)
+    expect(low.walkway1.exits.north).not.toBe(high.walkway1.exits.north)
   })
 
   it('throws when start room is missing', () => {

--- a/src/game/world.ts
+++ b/src/game/world.ts
@@ -14,9 +14,13 @@ export interface WorldConfig {
  * north–south fashion.
  *
  * @param config - world generation configuration
+ * @param rng - random number generator used to shuffle rooms
  * @returns generated world object
  */
-export function generateWorld(config: WorldConfig): World {
+export function generateWorld(
+  config: WorldConfig,
+  rng: () => number = Math.random
+): World {
   if (!config.rooms.start) {
     throw new Error('Start room is required')
   }
@@ -25,6 +29,12 @@ export function generateWorld(config: WorldConfig): World {
   world.start = { ...config.rooms.start, exits: {} }
 
   const others = Object.keys(config.rooms).filter(n => n !== 'start')
+
+  // Shuffle rooms using Fisher-Yates to produce a random layout
+  for (let i = others.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[others[i], others[j]] = [others[j], others[i]]
+  }
   let previous = 'start'
   others.forEach((name, idx) => {
     const walkwayName = `walkway${idx + 1}`

--- a/tests/store/game.spec.ts
+++ b/tests/store/game.spec.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../src/data/world', () => {
+  const world = {
+    start: { description: 'start', exits: { north: 'walkway1' } },
+    walkway1: {
+      description: 'walk',
+      exits: { south: 'start', north: 'kitchen' }
+    },
+    kitchen: { description: 'kitchen', exits: { south: 'walkway1' } }
+  }
+  return { world }
+})
+
 import { useGameStore } from '../../src/store/game'
 
 describe('useGameStore', () => {


### PR DESCRIPTION
## Summary
- randomize room order with RNG parameter for `generateWorld`
- update world generation tests for new behavior
- mock world in game store tests for determinism
- document randomness in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738316a624832f96ca5472619cbfd5